### PR TITLE
yovev/security-page-tweaks

### DIFF
--- a/app-client/.eslintrc.js
+++ b/app-client/.eslintrc.js
@@ -41,9 +41,6 @@ module.exports = {
 
       "react/display-name": ["off"],
 
-      // still debating on this rule
-      "react/jsx-curly-spacing": ["warn", "never"],
-
       "react/no-unescaped-entities": ["off"],
 
       // potentially fix at some point, still debating on this rule

--- a/app-client/src/Components/NotFoundPage/NotFound.js
+++ b/app-client/src/Components/NotFoundPage/NotFound.js
@@ -14,7 +14,7 @@ export default class Home extends Component {
               <h1 className={styles.notFoundText}>404</h1>
             </Col>
           </Row>
-          <Row className={``}>
+          <Row>
             <Col>
               <p>We're sorry, the page you requested could not be found.</p>
               <p>Try refining your search, or use the navigation above to locate your page.</p>

--- a/app-client/src/Components/Routes.js
+++ b/app-client/src/Components/Routes.js
@@ -11,7 +11,7 @@ import NotFoundPage from "./NotFoundPage/NotFound";
 import UserSettings from "./UserSettings/UserSettings";
 import ProtectedRoute from "./ProtectedRoute/ProtectedRoute";
 import ContactUs from "./ContactUs/ContactUs";
-import Securities from "./Securities/Securities";
+import Security from "./Security/Security";
 
 export default () =>
   <Switch>
@@ -22,8 +22,8 @@ export default () =>
     <Route path="/signup" exact component={Signup} />
     <Route path="/status" exact component={Status} />
     <Route path="/team" exact component={Team} />
-    <ProtectedRoute path="/userSettings" exact component={UserSettings} />
     <Route path="/contactUs" exact component={ContactUs} />
-    <Route path="/securities" exact component={Securities} />
+    <ProtectedRoute path="/userSettings" exact component={UserSettings} />
+    <ProtectedRoute path="/security/:symbol" exact component={Security} />
     <Route component={NotFoundPage} />
   </Switch>;

--- a/app-client/src/Components/Security/Security.css
+++ b/app-client/src/Components/Security/Security.css
@@ -1,10 +1,10 @@
+:local(.td1) {
+  border-bottom: 0.5px solid grey;
+}
+
 :local(.td2) {
   border-bottom: 0.5px solid grey;
   border-right: 1px solid grey;
-}
-
-:local(.td1){
-  border-bottom: 0.5px solid grey;
 }
 
 :local(.td3) {
@@ -44,7 +44,3 @@ h3 {
 #graphic {
   padding : 20vh;
 }
-
-
-
-

--- a/app-client/src/Components/Security/Security.js
+++ b/app-client/src/Components/Security/Security.js
@@ -1,21 +1,21 @@
 import React, { Component } from "react";
-import axios from "axios";
-import styles from './Securities.css';
 import { Container, Row } from 'reactstrap';
+import axios from "axios";
+import styles from './Security.css';
 
-export default class Securities extends Component {
+export default class Security extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      symbol: ``,
+      symbol: props.match.params.symbol,
       beta: ``,
+      expectedReturn: ``,
+      investabilityIndex: ``,
       rSquared: ``,
       sharpeRatio: ``,
       standardDeviation: ``,
-      expectedReturn: ``,
-      valueAtRisk: ``,
-      investabilityIndex: ``
+      valueAtRisk: ``
     };
   }
 
@@ -26,27 +26,26 @@ export default class Securities extends Component {
   getAnalysisData = async () => {
     const options = {
       method: `GET`,
-      url: `/api/security/MU`,
+      url: `/api/security/${this.state.symbol}`,
       resolveWithFullResponse: true
     };
 
     const response = await axios(options);
     const analysisData = response.data;
 
-    const { beta, rSquared, sharpeRatio, standardDeviation, expectedReturn, valueAtRisk, symbol, investabilityIndex } = analysisData;
+    const { symbol, beta, expectedReturn, investabilityIndex, rSquared, sharpeRatio, standardDeviation, valueAtRisk } = analysisData;
 
     this.setState({
+      symbol,
       beta,
+      expectedReturn,
+      investabilityIndex,
       rSquared,
       sharpeRatio,
       standardDeviation,
-      expectedReturn,
-      valueAtRisk,
-      symbol,
-      investabilityIndex
+      valueAtRisk
     });
   }
-
 
   render() {
     return (
@@ -62,7 +61,7 @@ export default class Securities extends Component {
             <h1>{this.state.symbol}</h1>
           </Row>
           <Row className="Row">
-              Micron
+              companyName
             <hr className={styles.hr2}/>
           </Row>
           <Row className="Row">

--- a/app-server/app.js
+++ b/app-server/app.js
@@ -3,7 +3,7 @@
 const express = require(`express`);
 const path = require(`path`);
 const cookieParser = require(`cookie-parser`);
-const logger = require(`morgan`);
+const morgan = require(`morgan`);
 
 const DATABASE_URI = require(`./database`);
 
@@ -19,13 +19,13 @@ const app = express();
 
 require(`mongodb`).MongoClient.connect(DATABASE_URI, { useNewUrlParser: true, poolSize: 10 }, (error, client) => {
   app.locals.MongoClient = client;
-  app.locals.Database = app.locals.MongoClient.db(`ieen`);
+  app.locals.Database = app.locals.MongoClient.db();
   app.locals.UsersCollection = app.locals.Database.collection(`users`);
   app.locals.PricedataCollection = app.locals.Database.collection(`pricedata`);
   app.locals.AnalysisCollection = app.locals.Database.collection(`analysis`);
 });
 
-app.use(logger(`combined`));
+app.use(morgan(`combined`));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());

--- a/app-server/routes/security.js
+++ b/app-server/routes/security.js
@@ -1,27 +1,30 @@
 `use strict`;
 
+const jwt = require(`jsonwebtoken`);
 const express = require(`express`);
 const router = express.Router();
 
 router.route(`/:symbol`)
-  // .get(async (request, response, next) => {
-  //   const symbol = request.params[`symbol`];
+// .get(async (request, response, next) => {
+//   const symbol = request.params[`symbol`];
 
-  //   const { PricedataCollection } = request.app.locals;
+//   const { PricedataCollection } = request.app.locals;
 
-  //   const historicalData = await PricedataCollection.findOne({ "metadata.symbol": symbol });
+//   const historicalData = await PricedataCollection.findOne({ "metadata.symbol": symbol });
 
-  //   console.log(Object.keys(historicalData));
+//   console.log(Object.keys(historicalData));
 
-  //   response.sendStatus(200);
-  // });
+//   response.sendStatus(200);
+// })
 
   .get(async (request, response, next) => {
-    const symbol = request.params[`symbol`];
+    const token = request.header(`Authorization`) || request.cookies[`pbiToken`];
+    await jwt.verify(token, process.env.TOKEN_SECRET);
 
     const { AnalysisCollection } = request.app.locals;
 
-    const analysisData = await AnalysisCollection.findOne({ "symbol": symbol });
+    const symbol = request.params[`symbol`].toUpperCase();
+    const analysisData = await AnalysisCollection.findOne({ symbol });
 
     response.status(200).send(analysisData);
   });


### PR DESCRIPTION
This small PR addresses some small issues with the initial version of the `Security` page including dynamic symbol rendering, renaming, and making the client-side route protected in order to restrict access to authenticated users only. There are also a couple of minor changes on server-side including a check for a valid JWT (still need to implement error-handling) before returning the analysis result. Pretty small and straight-forward but necessary tweaks nonetheless to keep us moving forward.