### PR TITLE
yovev/express-error-handling

### DIFF
--- a/app-client/src/Components/ContactUs/ContactUs.js
+++ b/app-client/src/Components/ContactUs/ContactUs.js
@@ -64,7 +64,7 @@ export default class ContactUs extends Component {
 
     const options = {
       method: `POST`,
-      url: `/api/email`,
+      url: `/api/emails`,
       data
     };
 

--- a/app-client/src/Components/Header/Header.js
+++ b/app-client/src/Components/Header/Header.js
@@ -25,7 +25,7 @@ export default class Header extends Component {
   getUserLetter = async () => {
     const options = {
       method: `GET`,
-      url: `/api/user/profilePicture`,
+      url: `/api/users/profilePicture`,
       resolveWithFullResponse: true
     };
 

--- a/app-client/src/Components/Security/Security.js
+++ b/app-client/src/Components/Security/Security.js
@@ -33,7 +33,7 @@ export default class Security extends Component {
   getAnalysisData = async () => {
     const options = {
       method: `GET`,
-      url: `/api/security/${this.state.symbol}`,
+      url: `/api/securities/${this.state.symbol}`,
       resolveWithFullResponse: true
     };
 
@@ -57,7 +57,7 @@ export default class Security extends Component {
   getListOfSecurities = async () => {
     const options = {
       method: `GET`,
-      url: `/api/security/`,
+      url: `/api/securities/`,
       resolveWithFullResponse: true
     };
 

--- a/app-client/src/Components/SecuritySearch/SecuritySearch.js
+++ b/app-client/src/Components/SecuritySearch/SecuritySearch.js
@@ -35,7 +35,7 @@ export default class SecuritySearch extends Component {
   getListOfSecurities = async () => {
     const options = {
       method: `GET`,
-      url: `/api/security/`,
+      url: `/api/securities/`,
       resolveWithFullResponse: true
     };
 

--- a/app-client/src/Components/Signup/Signup.js
+++ b/app-client/src/Components/Signup/Signup.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Alert, Form, FormGroup, Input, Button, Label } from 'reactstrap';
+import { Alert, Button, Form, FormGroup, Input, Label } from 'reactstrap';
 import { Line, LineChart } from 'recharts';
 import md5 from "md5";
 import axios from "axios";

--- a/app-client/src/Components/UserSettings/UserSettings.js
+++ b/app-client/src/Components/UserSettings/UserSettings.js
@@ -31,7 +31,7 @@ export default class UserSettings extends Component {
   getUserInfo = async () => {
     const options = {
       method: `GET`,
-      url: `/api/user/`,
+      url: `/api/users/`,
       resolveWithFullResponse: true
     };
 

--- a/app-client/src/Components/UserSettings/UserSettings.js
+++ b/app-client/src/Components/UserSettings/UserSettings.js
@@ -87,7 +87,7 @@ export default class UserSettings extends Component {
 
     const options = {
       method: `PUT`,
-      url: `/api/user`,
+      url: `/api/users`,
       data
     };
 

--- a/app-server/app.js
+++ b/app-server/app.js
@@ -35,8 +35,11 @@ app.use(`/api`, indexRouter);
 app.use(`/api/status`, statusRouter);
 app.use(`/api/authentication`, authenticationRouter);
 app.use(`/api/signup`, signupRouter);
-app.use(`/api/user`, userRouter);
-app.use(`/api/email`, emailRouter);
-app.use(`/api/security`, securityRouter);
+app.use(`/api/users`, userRouter);
+app.use(`/api/emails`, emailRouter);
+app.use(`/api/securities`, securityRouter);
+app.use((error, request, response, next) => {
+  response.status(500).send(error);
+});
 
 module.exports = app;

--- a/app-server/app.js
+++ b/app-server/app.js
@@ -39,6 +39,7 @@ app.use(`/api/users`, userRouter);
 app.use(`/api/emails`, emailRouter);
 app.use(`/api/securities`, securityRouter);
 app.use((error, request, response, next) => {
+  console.error(error);
   response.status(500).send(error);
 });
 app.use((request, response, next) => {

--- a/app-server/app.js
+++ b/app-server/app.js
@@ -41,5 +41,8 @@ app.use(`/api/securities`, securityRouter);
 app.use((error, request, response, next) => {
   response.status(500).send(error);
 });
+app.use((request, response, next) => {
+  response.sendStatus(404);
+});
 
 module.exports = app;

--- a/app-server/routes/email.js
+++ b/app-server/routes/email.js
@@ -6,20 +6,24 @@ const router = express.Router();
 
 router.route(`/`)
   .post(async (request, response, next) => {
-    const transport = {
-      service: `Gmail`,
-      auth: {
-        user: process.env.EMAIL,
-        pass: process.env.EMAIL_PASSWORD
+    try {
+      const transport = {
+        service: `Gmail`,
+        auth: {
+          user: process.env.EMAIL,
+          pass: process.env.EMAIL_PASSWORD
+        }
+      };
+
+      // const testTransporter = nodemailer.createTestAccount();
+
+      const transporter = nodemailer.createTransport(transport);
+      const ready = await transporter.verify();
+
+      if (!ready) {
+        response.status(503).send(`Error: Your message could not be sent. Please try again later.`);
       }
-    };
 
-    // const testTransporter = nodemailer.createTestAccount();
-
-    const transporter = nodemailer.createTransport(transport);
-    const ready = await transporter.verify();
-
-    if (ready) {
       const { email, inquiryType, subject, message } = request.body;
 
       const mail = {
@@ -31,14 +35,14 @@ router.route(`/`)
       const result = await transporter.sendMail(mail);
 
       if (result.accepted.length === 1 && result.rejected.length === 0) {
-        response.status(202).send(`Thank You For Contacting IEEN. Your Email Has Been Successfully Sent. Our Dedicated Team Will Respond To All Inquiries Within 1-2 Business Days.`);
+        response.status(202).send(`Thank you for contacting IEEN. Your email has been successfully sent. Our dedicated team will respond to all inquiries within 1-2 business days.`);
       }
       else {
-        response.status(400).send(`Error: Your Message Could Not Be Sent. Please Try Again Later.`);
+        response.status(400).send(`Error: Your message could not be sent. Please try again later.`);
       }
     }
-    else {
-      response.status(503).send(`Error: Your Message Could Not Be Sent. Please Try Again Later.`);
+    catch (error) {
+      next(error);
     }
   });
 

--- a/app-server/routes/security.js
+++ b/app-server/routes/security.js
@@ -6,13 +6,18 @@ const router = express.Router();
 
 router.route(`/`)
   .get(async (request, response, next) => {
-    const token = request.header(`Authorization`) || request.cookies[`pbiToken`];
-    await jwt.verify(token, process.env.TOKEN_SECRET);
+    try {
+      const token = request.header(`Authorization`) || request.cookies[`pbiToken`];
+      await jwt.verify(token, process.env.TOKEN_SECRET);
 
-    const { AnalysisCollection } = request.app.locals;
-    const symbols = await AnalysisCollection.find({}, { projection: { symbol: 1, _id: 0 } }).toArray();
+      const { AnalysisCollection } = request.app.locals;
+      const symbols = await AnalysisCollection.find({}, { projection: { symbol: 1, _id: 0 } }).toArray();
 
-    response.status(200).send(symbols);
+      response.status(200).send(symbols);
+    }
+    catch (error) {
+      next(error);
+    }
   });
 
 router.route(`/:symbol`)
@@ -29,15 +34,20 @@ router.route(`/:symbol`)
 // })
 
   .get(async (request, response, next) => {
-    const token = request.header(`Authorization`) || request.cookies[`pbiToken`];
-    await jwt.verify(token, process.env.TOKEN_SECRET);
+    try {
+      const token = request.header(`Authorization`) || request.cookies[`pbiToken`];
+      await jwt.verify(token, process.env.TOKEN_SECRET);
 
-    const symbol = request.params[`symbol`].toUpperCase();
+      const symbol = request.params[`symbol`].toUpperCase();
 
-    const { AnalysisCollection } = request.app.locals;
-    const analysisData = await AnalysisCollection.findOne({ symbol });
+      const { AnalysisCollection } = request.app.locals;
+      const analysisData = await AnalysisCollection.findOne({ symbol });
 
-    response.status(200).send(analysisData);
+      response.status(200).send(analysisData);
+    }
+    catch (error) {
+      next(error);
+    }
   });
 
 module.exports = router;

--- a/app-server/routes/signup.js
+++ b/app-server/routes/signup.js
@@ -5,32 +5,37 @@ const router = express.Router();
 
 router.route(`/`)
   .post(async (request, response, next) => {
-    const { UsersCollection } = request.app.locals;
+    try {
+      const { UsersCollection } = request.app.locals;
 
-    let user = await UsersCollection.findOne({ email: request.body.email });
+      let user = await UsersCollection.findOne({ email: request.body.email });
 
-    if (user) {
+      if (user) {
       // TODO @Nate: modify this to use some better more specific verbiage
-      response.status(422).send(`User already exists`);
-      return;
+        response.status(422).send(`User already exists`);
+        return;
+      }
+
+      user = {
+        firstName: request.body.firstName,
+        lastName: request.body.lastName,
+        birthdate: request.body.birthdate,
+        email: request.body.email,
+        password: request.body.password,
+        investmentStyle: request.body.investmentStyle,
+        profilePicture: `https://ui-avatars.com/api/?name=${request.body.firstName}+${request.body.lastName}&background=4286f4&color=000&rounded=true&size=32`,
+        role: `user`,
+        createdAt: new Date()
+      };
+
+      await UsersCollection.insertOne(user);
+
+      // TODO @Nate: modify this to use some better more specific verbiage
+      response.status(201).send();
     }
-
-    user = {
-      firstName: request.body.firstName,
-      lastName: request.body.lastName,
-      birthdate: request.body.birthdate,
-      email: request.body.email,
-      password: request.body.password,
-      investmentStyle: request.body.investmentStyle,
-      profilePicture: `https://ui-avatars.com/api/?name=${request.body.firstName}+${request.body.lastName}&background=4286f4&color=000&rounded=true&size=32`,
-      role: `user`,
-      createdAt: new Date()
-    };
-
-    await UsersCollection.insertOne(user);
-
-    // TODO @Nate: modify this to use some better more specific verbiage
-    response.status(201).send();
+    catch (error) {
+      next(error);
+    }
   });
 
 module.exports = router;

--- a/app-server/routes/signup.js
+++ b/app-server/routes/signup.js
@@ -25,7 +25,7 @@ router.route(`/`)
         investmentStyle: request.body.investmentStyle,
         profilePicture: `https://ui-avatars.com/api/?name=${request.body.firstName}+${request.body.lastName}&background=4286f4&color=000&rounded=true&size=32`,
         role: `user`,
-        createdAt: new Date()
+        createdAt: new Date().toISOString()
       };
 
       await UsersCollection.insertOne(user);

--- a/app-server/routes/status.js
+++ b/app-server/routes/status.js
@@ -4,8 +4,20 @@ const express = require(`express`);
 const router = express.Router();
 
 router.route(`/`)
-  .get((request, response, next) => {
-    response.sendStatus(200);
+  .get(async (request, response, next) => {
+    try {
+      const { Database } = request.app.locals;
+      const { ok } = await Database.command({ ping: 1 });
+
+      if (!ok) {
+        response.sendStatus(503);
+      }
+
+      response.sendStatus(200);
+    }
+    catch (error) {
+      next(error);
+    }
   });
 
 module.exports = router;

--- a/app-server/routes/user.js
+++ b/app-server/routes/user.js
@@ -8,45 +8,59 @@ const router = express.Router();
 
 router.route(`/profilePicture`)
   .get(async (request, response, next) => {
-    // still thinking about whether or not to allow authorization via header or just cookie...
-    let token = request.header(`Authorization`) || request.cookies[`pbiToken`];
-    token = await jwt.verify(token, process.env.TOKEN_SECRET);
-    const userID = token.data;
+    try {
+      let token = request.header(`Authorization`) || request.cookies[`pbiToken`];
+      token = await jwt.verify(token, process.env.TOKEN_SECRET);
+      const userID = token.data;
 
-    const { UsersCollection } = request.app.locals;
-    const user = await UsersCollection.findOne({ _id: ObjectID(userID) }, { projection: { profilePicture: 1, _id: 0 } });
-    const { profilePicture } = user;
+      const { UsersCollection } = request.app.locals;
+      const user = await UsersCollection.findOne({ _id: ObjectID(userID) }, { projection: { profilePicture: 1, _id: 0 } });
+      const { profilePicture } = user;
 
-    response.send(profilePicture);
+      response.send(profilePicture);
+    }
+    catch (error) {
+      next(error);
+    }
   });
 
 router.route(`/`)
   .get(async (request, response, next) => {
-    let token = request.header(`Authorization`) || request.cookies[`pbiToken`];
-    token = await jwt.verify(token, process.env.TOKEN_SECRET);
-    const userID = token.data;
+    try {
+      let token = request.header(`Authorization`) || request.cookies[`pbiToken`];
+      token = await jwt.verify(token, process.env.TOKEN_SECRET);
+      const userID = token.data;
 
-    const { UsersCollection } = request.app.locals;
-    const user = await UsersCollection.findOne({ _id: ObjectID(userID) }, { projection: { firstName: 1, lastName: 1, birthdate: 1, email: 1, investmentStyle: 1, profilePicture: 1, createdAt: 1, _id: 0 } });
+      const { UsersCollection } = request.app.locals;
+      const user = await UsersCollection.findOne({ _id: ObjectID(userID) }, { projection: { firstName: 1, lastName: 1, birthdate: 1, email: 1, investmentStyle: 1, profilePicture: 1, createdAt: 1, _id: 0 } });
 
-    response.send(user);
+      response.send(user);
+    }
+    catch (error) {
+      next(error);
+    }
   })
   .put(async (request, response, next) => {
-    let token = request.header(`Authorization`) || request.cookies[`pbiToken`];
-    token = await jwt.verify(token, process.env.TOKEN_SECRET);
-    const userID = token.data;
+    try {
+      let token = request.header(`Authorization`) || request.cookies[`pbiToken`];
+      token = await jwt.verify(token, process.env.TOKEN_SECRET);
+      const userID = token.data;
 
-    // we should add validation here to ensure that nothing bad is being pushed to the DB.
-    const updatedUserData = request.body;
+      // we should add validation here to ensure that nothing bad is being pushed to the DB.
+      const updatedUserData = request.body;
 
-    const { UsersCollection } = request.app.locals;
-    const { result } = await UsersCollection.updateOne({ _id: ObjectID(userID) }, { $set: updatedUserData });
+      const { UsersCollection } = request.app.locals;
+      const { result } = await UsersCollection.updateOne({ _id: ObjectID(userID) }, { $set: updatedUserData });
 
-    if (result.ok) {
-      response.sendStatus(200);
+      if (result.ok) {
+        response.sendStatus(200);
+      }
+      else {
+        response.sendStatus(400);
+      }
     }
-    else {
-      response.sendStatus(400);
+    catch (error) {
+      next(error);
     }
   });
 

--- a/app-server/routes/user.js
+++ b/app-server/routes/user.js
@@ -46,10 +46,18 @@ router.route(`/`)
       token = await jwt.verify(token, process.env.TOKEN_SECRET);
       const userID = token.data;
 
+      const { UsersCollection } = request.app.locals;
+
+      const user = await UsersCollection.findOne({ email: request.body.email });
+
+      if (user) {
+        response.status(422).send(`User already exists`);
+        return;
+      }
+
       // we should add validation here to ensure that nothing bad is being pushed to the DB.
       const updatedUserData = request.body;
 
-      const { UsersCollection } = request.app.locals;
       const { result } = await UsersCollection.updateOne({ _id: ObjectID(userID) }, { $set: updatedUserData });
 
       if (result.ok) {


### PR DESCRIPTION
This PR covers issues #34 and #33 to implement a catchall error handler and better exception handling in all existing routes. Moving forward we should try to follow the pattern you'll see here of wrapping everything in a `try-catch` block, doing whatever you're going to do in the `try` and then handle any processing exceptions in the `catch` by calling `next(error)`. This will automatically invoke the error handler to `console.error` whatever happened and send a `500` back to the requester. I also "restified"/pluralized the Express API routes so they make more sense when interacting with the resource. The last thing that I added to the Express API was a database ping on the health check (`status` endpoint) to make sure that the API has a connection to the database.